### PR TITLE
fix: qualify based an CPU manufacturer only

### DIFF
--- a/pkg/tests/server_class.go
+++ b/pkg/tests/server_class.go
@@ -40,7 +40,6 @@ func (suite *TestSuite) TestServerClassDefault(t *testing.T) {
 		serverClass.Name = serverClassName
 		serverClass.Spec.Qualifiers.CPU = append(serverClass.Spec.Qualifiers.CPU, v1alpha1.CPUInformation{
 			Manufacturer: "QEMU",
-			Version:      "pc-q35-4.2",
 		})
 
 		require.NoError(t, metalClient.Create(suite.ctx, &serverClass))


### PR DESCRIPTION
The CPU version could be different in different versions of QEMU.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>
